### PR TITLE
Fix issue #11 - Change full name to "Google Redirects Fixer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-no-tracking-url",
-  "fullName": "google-no-tracking-url",
+  "fullName": "Google Redirects Fixer",
   "id": "jid1-zUrvDCat3xoDSQ",
   "description": "It simply removes tracking code/redirect from Google search results.",
   "author": "Matias Agustin Mendez",


### PR DESCRIPTION
The addon name is "Google Redirects Fixer", but after installation, in the installed extensions page, the name shows up as "google-no-tracking-url". So fixing it to match the addon name. This will fix issue #11 