### PR TITLE
Fix URL overwriting of requests not made for tab

### DIFF
--- a/background/http-interceptor.js
+++ b/background/http-interceptor.js
@@ -54,6 +54,12 @@ function logURL(requestDetails) {
 
     console.log("Opening: " + to_url);
 
+    if (requestDetails.type != "sub_frame") {
+      return {
+        redirectUrl: to_url
+      };
+    }
+
     browser.tabs.update(requestDetails.tabId, {url: to_url});
     return {cancel: true};
   }


### PR DESCRIPTION
Fixes #35.

This PR fixes overwriting tab address incorrectly when URL redirection is done while loading scripts, images, styles etc. See #35 for two examples. This seems like the preferred approach for redirecting requests [per MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests#Redirecting_requests) as well.

ps. Also fixes #24 and perhaps some others, which #35 is probably duplicate of.